### PR TITLE
Add GET_APP_URL Message Handling to Sync App URL with WebView

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -299,6 +299,18 @@ const App: React.FC = () => {
     try {
       const data = JSON.parse(event.nativeEvent.data);
 
+      if (data.type === "GET_APP_URL") {
+        // Get the current app_url from AsyncStorage or use the default
+        const url = (await AsyncStorage.getItem(APP_URL_KEY)) || APP_URL;
+        // Send it back to the WebView
+        if (webViewRef.current) {
+          webViewRef.current.postMessage(
+            JSON.stringify({ type: "APP_URL", url })
+          );
+        }
+        return;
+      }
+
       if (data.type === "EXPORT_BACKUP") {
         const { dataUrl, filename } = data;
         console.log("📦 Received backup file");

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Liberdus",
     "slug": "liberdus",
-    "version": "2025.07.17.02.09",
+    "version": "2025.07.23.22.35",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",


### PR DESCRIPTION
**Reason for PR:**
- Enable the WebView (web client) to request and receive the current app URL (`app_url`) stored in AsyncStorage (or the default) from the React Native app.
- Supports scenarios where the web client needs to prefill or sync with the native app’s current URL state.

**Changes Made:**
- Added a new message type (`GET_APP_URL`) to the `handleWebViewMessage` function in `App.tsx`.
- When the WebView sends a `GET_APP_URL` message, the React Native app retrieves the current `app_url` from AsyncStorage (or falls back to the default `APP_URL`).
- The app then sends the URL back to the WebView using `postMessage` with a message of type `APP_URL`.
- This enables seamless communication and state synchronization between the native app and the embedded web client.