### PR TITLE
Add notification response handling to capture tapped notification data

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -256,6 +256,7 @@ const App: React.FC = () => {
         sendMessageToWebView({
           type: "NOTIFICATION_TAPPED",
           to: data.to,
+          from: data.from,
         });
       });
   

--- a/App.tsx
+++ b/App.tsx
@@ -245,6 +245,26 @@ const App: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    // Listen for notification response (when user taps notification)
+    const notificationResponseListener =
+      Notifications.addNotificationResponseReceivedListener((response) => {
+        const { notification } = response;
+        const { data } = notification.request.content;
+  
+        console.log("👆 Notification tapped:", { data });
+  
+        sendMessageToWebView({
+          type: "NOTIFICATION_TAPPED",
+          to: data.to,
+        });
+      });
+  
+    return () => {
+      notificationResponseListener.remove();
+    };
+  }, []);
+
+  useEffect(() => {
     console.log("📱 Launched once:", hasLaunchedOnce);
     openBrowser();
   }, [hasLaunchedOnce]);


### PR DESCRIPTION
## PR Summary
- **Purpose**: Enable the native app to capture and forward notification data when users tap on push notifications
- **Changes Made**:
  - Added `addNotificationResponseReceivedListener` to detect when users tap notifications
  - Implemented data extraction from notification response to get the recipient address (`to`) and 'from'
  - Added WebView messaging to forward notification tap events to the web application

This enhancement allows the web application to receive the recipient address when a notification is tapped, enabling proper navigation and context-aware handling of notification interactions.