### PR TITLE
Add a delay before sending INITIAL_APP_PARAMS to WebView

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -759,10 +759,12 @@ const App: React.FC = () => {
                   data.expoPushToken = expoPushToken;
                 }
                 console.log("🚀 Initial app parameters:", data);
+                setTimeout(() => {
                 sendMessageToWebView({
-                  type: "INITIAL_APP_PARAMS",
-                  data,
-                });
+                    type: "INITIAL_APP_PARAMS",
+                    data,
+                  });
+                }, 200);
               }}
               // Add load start handler
               onLoadStart={() => {


### PR DESCRIPTION
* Introduced a 200ms timeout to improve the timing of the message sent to the WebView, ensuring that initial app parameters are logged and sent correctly.