### PR TITLE
Add notification handling on app resume and start

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -759,10 +759,12 @@ const App: React.FC = () => {
                   data.expoPushToken = expoPushToken;
                 }
                 console.log("🚀 Initial app parameters:", data);
+                setTimeout(() => {
                 sendMessageToWebView({
-                  type: "INITIAL_APP_PARAMS",
-                  data,
-                });
+                    type: "INITIAL_APP_PARAMS",
+                    data,
+                  });
+                }, 200);
               }}
               // Add load start handler
               onLoadStart={() => {


### PR DESCRIPTION
* Implemented a new function to check for presented notifications and send them to the WebView.
* Added logic to check for notifications when the app resumes and starts, ensuring timely updates.
* Enhanced notification tap handling to exclude the tapped notification from the presented notifications sent to the WebView.