### PR TITLE
Add native location bridge and WebView trust policy

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -23,6 +23,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Crypto from "expo-crypto";
 import Constants from "expo-constants";
 import * as FileSystem from "expo-file-system";
+import * as Location from "expo-location";
 import * as Sharing from "expo-sharing";
 import FileViewer from "react-native-file-viewer";
 import AnimatedSplash from "./SplashScreen";
@@ -521,6 +522,86 @@ const App: React.FC = () => {
     }
   };
 
+  const getRequestId = (data: any): string | undefined =>
+    typeof data?.requestId === "string" ? data.requestId : undefined;
+
+  const requestLocationPermissionForWebView = async (requestId?: string) => {
+    try {
+      const permission = await Location.requestForegroundPermissionsAsync();
+
+      sendMessageToWebView({
+        type: "LOCATION_PERMISSION_RESULT",
+        requestId,
+        status: permission.status,
+        granted: permission.granted,
+        canAskAgain: permission.canAskAgain,
+      });
+
+      return permission;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error("❌ Failed to request location permission:", error);
+      sendMessageToWebView({
+        type: "LOCATION_PERMISSION_RESULT",
+        requestId,
+        status: "error",
+        granted: false,
+        canAskAgain: false,
+        message,
+      });
+      return null;
+    }
+  };
+
+  const sendCurrentLocationToWebView = async (requestId?: string) => {
+    try {
+      const permission = await Location.requestForegroundPermissionsAsync();
+
+      if (!permission.granted) {
+        sendMessageToWebView({
+          type: "CURRENT_LOCATION",
+          requestId,
+          status: permission.status,
+          granted: false,
+          canAskAgain: permission.canAskAgain,
+        });
+        return;
+      }
+
+      const location = await Location.getCurrentPositionAsync({
+        accuracy: Location.Accuracy.Balanced,
+      });
+
+      sendMessageToWebView({
+        type: "CURRENT_LOCATION",
+        requestId,
+        status: "granted",
+        granted: true,
+        canAskAgain: permission.canAskAgain,
+        coords: {
+          latitude: location.coords.latitude,
+          longitude: location.coords.longitude,
+          accuracy: location.coords.accuracy,
+          altitude: location.coords.altitude,
+          altitudeAccuracy: location.coords.altitudeAccuracy,
+          heading: location.coords.heading,
+          speed: location.coords.speed,
+        },
+        timestamp: location.timestamp,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error("❌ Failed to get current location:", error);
+      sendMessageToWebView({
+        type: "CURRENT_LOCATION",
+        requestId,
+        status: "error",
+        granted: false,
+        message,
+      });
+    }
+  };
+
   useEffect(() => {
     (async () => {
       // await AsyncStorage.removeItem(APP_URL_KEY);
@@ -1006,6 +1087,18 @@ const App: React.FC = () => {
           type: "ALL_NOTIFICATIONS_IN_PANEL",
           notifications,
         });
+        return;
+      }
+
+      if (data.type === "REQUEST_LOCATION_PERMISSION") {
+        console.log("📍 WebView requested location permission");
+        await requestLocationPermissionForWebView(getRequestId(data));
+        return;
+      }
+
+      if (data.type === "GET_CURRENT_LOCATION") {
+        console.log("📍 WebView requested current location");
+        await sendCurrentLocationToWebView(getRequestId(data));
         return;
       }
 

--- a/App.tsx
+++ b/App.tsx
@@ -522,9 +522,6 @@ const App: React.FC = () => {
     }
   };
 
-  const getRequestId = (data: any): string | undefined =>
-    typeof data?.requestId === "string" ? data.requestId : undefined;
-
   const isTrustedLiberdusUrl = (url?: string): boolean => {
     if (!url) return false;
 
@@ -537,53 +534,6 @@ const App: React.FC = () => {
       );
     } catch {
       return false;
-    }
-  };
-
-  const getWebViewMessageUrl = (event: any): string | undefined => {
-    const messageUrl = event?.nativeEvent?.url;
-    return typeof messageUrl === "string" ? messageUrl : webViewUrl;
-  };
-
-  const sendLocationBridgeRejected = (
-    responseType: "LOCATION_PERMISSION_RESULT" | "CURRENT_LOCATION",
-    requestId?: string
-  ) => {
-    sendMessageToWebView({
-      type: responseType,
-      requestId,
-      status: "error",
-      granted: false,
-      canAskAgain: false,
-      message: "Location requests are only allowed from trusted Liberdus pages.",
-    });
-  };
-
-  const requestLocationPermissionForWebView = async (requestId?: string) => {
-    try {
-      const permission = await Location.requestForegroundPermissionsAsync();
-
-      sendMessageToWebView({
-        type: "LOCATION_PERMISSION_RESULT",
-        requestId,
-        status: permission.status,
-        granted: permission.granted,
-        canAskAgain: permission.canAskAgain,
-      });
-
-      return permission;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error("❌ Failed to request location permission:", error);
-      sendMessageToWebView({
-        type: "LOCATION_PERMISSION_RESULT",
-        requestId,
-        status: "error",
-        granted: false,
-        canAskAgain: false,
-        message,
-      });
-      return null;
     }
   };
 
@@ -631,6 +581,7 @@ const App: React.FC = () => {
         requestId,
         status: "error",
         granted: false,
+        canAskAgain: false,
         message,
       });
     }
@@ -1124,26 +1075,30 @@ const App: React.FC = () => {
         return;
       }
 
-      if (data.type === "REQUEST_LOCATION_PERMISSION") {
-        console.log("📍 WebView requested location permission");
-        const requestId = getRequestId(data);
-        if (!isTrustedLiberdusUrl(getWebViewMessageUrl(event))) {
-          console.warn("📍 Rejected location permission request from untrusted page");
-          sendLocationBridgeRejected("LOCATION_PERMISSION_RESULT", requestId);
-          return;
-        }
-        await requestLocationPermissionForWebView(requestId);
-        return;
-      }
-
       if (data.type === "GET_CURRENT_LOCATION") {
         console.log("📍 WebView requested current location");
-        const requestId = getRequestId(data);
-        if (!isTrustedLiberdusUrl(getWebViewMessageUrl(event))) {
+
+        const requestId =
+          typeof data.requestId === "string" ? data.requestId : undefined;
+        const messageUrl =
+          typeof event.nativeEvent.url === "string"
+            ? event.nativeEvent.url
+            : webViewUrl;
+
+        if (!isTrustedLiberdusUrl(messageUrl)) {
           console.warn("📍 Rejected current location request from untrusted page");
-          sendLocationBridgeRejected("CURRENT_LOCATION", requestId);
+          sendMessageToWebView({
+            type: "CURRENT_LOCATION",
+            requestId,
+            status: "error",
+            granted: false,
+            canAskAgain: false,
+            message:
+              "Location requests are only allowed from trusted Liberdus pages.",
+          });
           return;
         }
+
         await sendCurrentLocationToWebView(requestId);
         return;
       }

--- a/App.tsx
+++ b/App.tsx
@@ -522,21 +522,6 @@ const App: React.FC = () => {
     }
   };
 
-  const isTrustedLiberdusUrl = (url?: string): boolean => {
-    if (!url) return false;
-
-    try {
-      const parsed = new URL(url);
-      return (
-        parsed.protocol === "https:" &&
-        (parsed.hostname === "liberdus.com" ||
-          parsed.hostname.endsWith(".liberdus.com"))
-      );
-    } catch {
-      return false;
-    }
-  };
-
   const sendCurrentLocationToWebView = async (requestId?: string) => {
     try {
       const permission = await Location.requestForegroundPermissionsAsync();
@@ -1077,27 +1062,8 @@ const App: React.FC = () => {
 
       if (data.type === "GET_CURRENT_LOCATION") {
         console.log("📍 WebView requested current location");
-
         const requestId =
           typeof data.requestId === "string" ? data.requestId : undefined;
-        const messageUrl =
-          typeof event.nativeEvent.url === "string"
-            ? event.nativeEvent.url
-            : webViewUrl;
-
-        if (!isTrustedLiberdusUrl(messageUrl)) {
-          console.warn("📍 Rejected current location request from untrusted page");
-          sendMessageToWebView({
-            type: "CURRENT_LOCATION",
-            requestId,
-            status: "error",
-            granted: false,
-            canAskAgain: false,
-            message:
-              "Location requests are only allowed from trusted Liberdus pages.",
-          });
-          return;
-        }
 
         await sendCurrentLocationToWebView(requestId);
         return;

--- a/App.tsx
+++ b/App.tsx
@@ -42,7 +42,21 @@ import type { FirebaseMessagingTypes } from "@react-native-firebase/messaging";
 import VoipPushNotification from "react-native-voip-push-notification";
 
 const APP_URL = "https://liberdus.com/test/";
-const TRUSTED_LOCATION_HOSTS = ["liberdus.com", "arimaa.com"];
+const TRUSTED_BRIDGE_HOSTS = ["liberdus.com", "arimaa.com"];
+const SENSITIVE_BRIDGE_MESSAGE_TYPES = new Set([
+  "APP_PARAMS",
+  "CANCEL_SCHEDULE_CALL",
+  "CLEAR_NOTI",
+  "DOWNLOAD_ATTACHMENT",
+  "EXPORT_BACKUP",
+  "GET_CURRENT_LOCATION",
+  "GetAllPanelNotifications",
+  "GOOGLE_OAUTH_REQUEST",
+  "NAV_BAR",
+  "SCHEDULE_CALL",
+  "SHARE_INVITE",
+  "launch",
+]);
 
 // Storage keys
 const DEVICE_TOKEN_KEY = "device_token";
@@ -50,20 +64,33 @@ const APP_URL_KEY = "app_url";
 
 const APP_RESUME_DELAY_MS = 1500; // 1.5 second delay before checking for app resume
 
-const isTrustedLocationUrl = (url?: string): boolean => {
+const isTrustedBridgeUrl = (url?: string): boolean => {
   if (!url) return false;
 
   try {
     const { hostname, protocol } = new URL(url);
-    if (protocol !== "https:") return false;
+    const isHttpsTrustedHost =
+      protocol === "https:" &&
+      TRUSTED_BRIDGE_HOSTS.some(
+        (trustedHost) =>
+          hostname === trustedHost || hostname.endsWith("." + trustedHost)
+      );
 
-    return TRUSTED_LOCATION_HOSTS.some(
-      (trustedHost) =>
-        hostname === trustedHost || hostname.endsWith("." + trustedHost)
-    );
+    if (isHttpsTrustedHost) return true;
+
+    return __DEV__ && (protocol === "http:" || protocol === "https:");
   } catch {
     return false;
   }
+};
+
+const isSensitiveBridgeMessage = (messageType: unknown): messageType is string =>
+  typeof messageType === "string" &&
+  SENSITIVE_BRIDGE_MESSAGE_TYPES.has(messageType);
+
+const getBridgeRequestUrl = (event: any, fallbackUrl: string): string => {
+  const eventUrl = event?.nativeEvent?.url;
+  return typeof eventUrl === "string" ? eventUrl : fallbackUrl;
 };
 
 interface APP_PARAMS {
@@ -429,6 +456,28 @@ const App: React.FC = () => {
     }
   };
 
+  const sendRejectedBridgeRequest = (
+    messageType: string,
+    requestId?: string
+  ) => {
+    sendMessageToWebView({
+      type: "BRIDGE_REQUEST_REJECTED",
+      requestedType: messageType,
+      requestId,
+      status: "untrusted_origin",
+    });
+
+    if (messageType === "GET_CURRENT_LOCATION") {
+      sendMessageToWebView({
+        type: "CURRENT_LOCATION",
+        requestId,
+        status: "untrusted_origin",
+        granted: false,
+        canAskAgain: false,
+      });
+    }
+  };
+
   /**
    * Get all notifications and return them
    * @returns Array of notifications in the panel
@@ -539,26 +588,8 @@ const App: React.FC = () => {
     }
   };
 
-  const sendCurrentLocationToWebView = async (
-    requestId?: string,
-    requestUrl?: string
-  ) => {
+  const sendCurrentLocationToWebView = async (requestId?: string) => {
     try {
-      if (!isTrustedLocationUrl(requestUrl)) {
-        console.warn(
-          "📍 Ignoring location request from untrusted URL:",
-          requestUrl
-        );
-        sendMessageToWebView({
-          type: "CURRENT_LOCATION",
-          requestId,
-          status: "untrusted_origin",
-          granted: false,
-          canAskAgain: false,
-        });
-        return;
-      }
-
       const permission = await Location.requestForegroundPermissionsAsync();
 
       if (!permission.granted) {
@@ -1081,6 +1112,23 @@ const App: React.FC = () => {
   const handleWebViewMessage = async (event: any) => {
     try {
       const data = JSON.parse(event.nativeEvent.data);
+      const messageType = data.type;
+      const requestId =
+        typeof data.requestId === "string" ? data.requestId : undefined;
+      const requestUrl = getBridgeRequestUrl(event, webViewUrl);
+
+      if (
+        isSensitiveBridgeMessage(messageType) &&
+        !isTrustedBridgeUrl(requestUrl)
+      ) {
+        console.warn(
+          "🔒 Rejected sensitive bridge message from untrusted URL:",
+          messageType,
+          requestUrl
+        );
+        sendRejectedBridgeRequest(messageType, requestId);
+        return;
+      }
 
       // console.log("📡 Received message:", data);
 
@@ -1097,15 +1145,7 @@ const App: React.FC = () => {
 
       if (data.type === "GET_CURRENT_LOCATION") {
         console.log("📍 WebView requested current location");
-        const requestId =
-          typeof data.requestId === "string" ? data.requestId : undefined;
-
-        const requestUrl =
-          typeof event.nativeEvent.url === "string"
-            ? event.nativeEvent.url
-            : webViewUrl;
-
-        await sendCurrentLocationToWebView(requestId, requestUrl);
+        await sendCurrentLocationToWebView(requestId);
         return;
       }
 

--- a/App.tsx
+++ b/App.tsx
@@ -525,6 +525,40 @@ const App: React.FC = () => {
   const getRequestId = (data: any): string | undefined =>
     typeof data?.requestId === "string" ? data.requestId : undefined;
 
+  const isTrustedLiberdusUrl = (url?: string): boolean => {
+    if (!url) return false;
+
+    try {
+      const parsed = new URL(url);
+      return (
+        parsed.protocol === "https:" &&
+        (parsed.hostname === "liberdus.com" ||
+          parsed.hostname.endsWith(".liberdus.com"))
+      );
+    } catch {
+      return false;
+    }
+  };
+
+  const getWebViewMessageUrl = (event: any): string | undefined => {
+    const messageUrl = event?.nativeEvent?.url;
+    return typeof messageUrl === "string" ? messageUrl : webViewUrl;
+  };
+
+  const sendLocationBridgeRejected = (
+    responseType: "LOCATION_PERMISSION_RESULT" | "CURRENT_LOCATION",
+    requestId?: string
+  ) => {
+    sendMessageToWebView({
+      type: responseType,
+      requestId,
+      status: "error",
+      granted: false,
+      canAskAgain: false,
+      message: "Location requests are only allowed from trusted Liberdus pages.",
+    });
+  };
+
   const requestLocationPermissionForWebView = async (requestId?: string) => {
     try {
       const permission = await Location.requestForegroundPermissionsAsync();
@@ -1092,13 +1126,25 @@ const App: React.FC = () => {
 
       if (data.type === "REQUEST_LOCATION_PERMISSION") {
         console.log("📍 WebView requested location permission");
-        await requestLocationPermissionForWebView(getRequestId(data));
+        const requestId = getRequestId(data);
+        if (!isTrustedLiberdusUrl(getWebViewMessageUrl(event))) {
+          console.warn("📍 Rejected location permission request from untrusted page");
+          sendLocationBridgeRejected("LOCATION_PERMISSION_RESULT", requestId);
+          return;
+        }
+        await requestLocationPermissionForWebView(requestId);
         return;
       }
 
       if (data.type === "GET_CURRENT_LOCATION") {
         console.log("📍 WebView requested current location");
-        await sendCurrentLocationToWebView(getRequestId(data));
+        const requestId = getRequestId(data);
+        if (!isTrustedLiberdusUrl(getWebViewMessageUrl(event))) {
+          console.warn("📍 Rejected current location request from untrusted page");
+          sendLocationBridgeRejected("CURRENT_LOCATION", requestId);
+          return;
+        }
+        await sendCurrentLocationToWebView(requestId);
         return;
       }
 
@@ -1388,7 +1434,6 @@ const App: React.FC = () => {
               webviewDebuggingEnabled={true}
               source={{ uri: webViewUrl }}
               style={styles.webView}
-              geolocationEnabled={true}
               allowsInlineMediaPlayback={true} // ✅ Required for <video> on iOS
               mediaPlaybackRequiresUserAction={false} // ✅ Let camera start automatically
               // mediaCapturePermissionGrantType={"grant"} // ✅ Prompt for media capture permissions

--- a/App.tsx
+++ b/App.tsx
@@ -42,12 +42,29 @@ import type { FirebaseMessagingTypes } from "@react-native-firebase/messaging";
 import VoipPushNotification from "react-native-voip-push-notification";
 
 const APP_URL = "https://liberdus.com/test/";
+const TRUSTED_LOCATION_HOSTS = ["liberdus.com", "arimaa.com"];
 
 // Storage keys
 const DEVICE_TOKEN_KEY = "device_token";
 const APP_URL_KEY = "app_url";
 
 const APP_RESUME_DELAY_MS = 1500; // 1.5 second delay before checking for app resume
+
+const isTrustedLocationUrl = (url?: string): boolean => {
+  if (!url) return false;
+
+  try {
+    const { hostname, protocol } = new URL(url);
+    if (protocol !== "https:") return false;
+
+    return TRUSTED_LOCATION_HOSTS.some(
+      (trustedHost) =>
+        hostname === trustedHost || hostname.endsWith("." + trustedHost)
+    );
+  } catch {
+    return false;
+  }
+};
 
 interface APP_PARAMS {
   appVersion: string;
@@ -522,8 +539,26 @@ const App: React.FC = () => {
     }
   };
 
-  const sendCurrentLocationToWebView = async (requestId?: string) => {
+  const sendCurrentLocationToWebView = async (
+    requestId?: string,
+    requestUrl?: string
+  ) => {
     try {
+      if (!isTrustedLocationUrl(requestUrl)) {
+        console.warn(
+          "📍 Ignoring location request from untrusted URL:",
+          requestUrl
+        );
+        sendMessageToWebView({
+          type: "CURRENT_LOCATION",
+          requestId,
+          status: "untrusted_origin",
+          granted: false,
+          canAskAgain: false,
+        });
+        return;
+      }
+
       const permission = await Location.requestForegroundPermissionsAsync();
 
       if (!permission.granted) {
@@ -1065,7 +1100,12 @@ const App: React.FC = () => {
         const requestId =
           typeof data.requestId === "string" ? data.requestId : undefined;
 
-        await sendCurrentLocationToWebView(requestId);
+        const requestUrl =
+          typeof event.nativeEvent.url === "string"
+            ? event.nativeEvent.url
+            : webViewUrl;
+
+        await sendCurrentLocationToWebView(requestId, requestUrl);
         return;
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "expo-device": "~7.1.4",
         "expo-file-system": "~18.1.11",
         "expo-linking": "^7.1.6",
-        "expo-location": "~19.0.8",
+        "expo-location": "~18.1.6",
         "expo-navigation-bar": "~4.2.7",
         "expo-notifications": "~0.31.3",
         "expo-sharing": "~13.1.5",
@@ -5732,9 +5732,9 @@
       }
     },
     "node_modules/expo-location": {
-      "version": "19.0.8",
-      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-19.0.8.tgz",
-      "integrity": "sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA==",
+      "version": "18.1.6",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-18.1.6.tgz",
+      "integrity": "sha512-l5dQQ2FYkrBgNzaZN1BvSmdhhcztFOUucu2kEfDBMV4wSIuTIt/CKsho+F3RnAiWgvui1wb1WTTf80E8zq48hA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "expo-device": "~7.1.4",
         "expo-file-system": "~18.1.11",
         "expo-linking": "^7.1.6",
+        "expo-location": "~19.0.8",
         "expo-navigation-bar": "~4.2.7",
         "expo-notifications": "~0.31.3",
         "expo-sharing": "~13.1.5",
@@ -5728,6 +5729,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-location": {
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-19.0.8.tgz",
+      "integrity": "sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-manifests": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "expo-device": "~7.1.4",
     "expo-file-system": "~18.1.11",
     "expo-linking": "^7.1.6",
-    "expo-location": "~19.0.8",
+    "expo-location": "~18.1.6",
     "expo-navigation-bar": "~4.2.7",
     "expo-notifications": "~0.31.3",
     "expo-sharing": "~13.1.5",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "expo-device": "~7.1.4",
     "expo-file-system": "~18.1.11",
     "expo-linking": "^7.1.6",
+    "expo-location": "~19.0.8",
     "expo-navigation-bar": "~4.2.7",
     "expo-notifications": "~0.31.3",
     "expo-sharing": "~13.1.5",


### PR DESCRIPTION
## What Changed

This PR moves the follow-up geolocation hardening out of PR #29 and into the native bridge/trust-policy track.

- `GET_CURRENT_LOCATION` / `CURRENT_LOCATION` adds an explicit native location bridge using `expo-location`.
- `geolocationEnabled={true}` is removed so location access goes through the controlled native bridge instead of broad WebView browser geolocation.
- Sensitive WebView bridge messages are validated at the native `onMessage` boundary before native capabilities run.
- Trusted production bridge access is limited to HTTPS pages on `liberdus.com`, `arimaa.com`, and their subdomains.
- Development builds still allow custom HTTP/HTTPS WebView URLs for local and test workflows.
- Rejected sensitive bridge requests return `BRIDGE_REQUEST_REJECTED`; rejected location requests also preserve the `CURRENT_LOCATION` error response shape.

## Fixed Flow

1. PR #29 enables the simple WebView geolocation path for issue #28.
2. A loaded WebView page sends a sensitive bridge message.
3. Native checks whether the message type requires trust and whether the current WebView URL is trusted.
4. Trusted requests continue to the native action; untrusted requests are rejected before native permissions, file actions, OAuth, notifications, or location access run.

## Why

The browser geolocation path is simple and useful for the initial issue, but the native app already exposes several sensitive WebView-to-native bridge capabilities. Centralizing trust validation keeps these capabilities explicit and gives native code a security boundary before returning location, launching OAuth, writing files, clearing notifications, or scheduling calls.

## Validation

- `git diff --check`
- TypeScript transpile/syntax check for `App.tsx`
- `npx tsc --noEmit` still fails on the existing `tsconfig.json` `customConditions` / `moduleResolution` mismatch before reaching this change.

Closes #30
