### PR TITLE
Preserve notification taps across Android cold starts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -409,15 +409,14 @@ const App: React.FC = () => {
     return () => sub.remove();
   }, []);
 
-  const sendMessageToWebView = (message: object): boolean => {
+  const sendMessageToWebView = (message: object) => {
     const messageJson = JSON.stringify(message);
-    if (!webViewRef.current) return false;
-
-    const jsToInject = `window.dispatchEvent(new MessageEvent('message', { data: ${JSON.stringify(
-      messageJson
-    )} }));`;
-    webViewRef.current.injectJavaScript(jsToInject);
-    return true;
+    if (webViewRef.current) {
+      const jsToInject = `window.dispatchEvent(new MessageEvent('message', { data: ${JSON.stringify(
+        messageJson
+      )} }));`;
+      webViewRef.current.injectJavaScript(jsToInject);
+    }
   };
 
   const clearLastNotificationResponse = () => {
@@ -428,13 +427,12 @@ const App: React.FC = () => {
 
   const flushPendingNotificationTap = () => {
     const pendingTap = pendingNotificationTapRef.current;
-    if (!webBridgeReadyRef.current || !pendingTap) return;
+    if (!webBridgeReadyRef.current || !webViewRef.current || !pendingTap) return;
 
-    const wasSent = sendMessageToWebView({
+    sendMessageToWebView({
       type: "NOTIFICATION_TAPPED",
       to: pendingTap.to,
     });
-    if (!wasSent) return;
 
     pendingNotificationTapRef.current = null;
     lastDeliveredNotificationIdRef.current = pendingTap.notificationId;
@@ -461,34 +459,20 @@ const App: React.FC = () => {
     flushPendingNotificationTap();
   };
 
-  const handleNotificationTap = (
+  const handleNotificationTap = async (
     notificationId: string,
     data: Record<string, unknown> | undefined
-  ): void => {
-    const tap = createNotificationTap(notificationId, data);
-    if (tap) {
-      queueNotificationTap(tap);
-      return;
+  ): Promise<void> => {
+    try {
+      const tap =
+        createNotificationTap(notificationId, data) ??
+        (await getPendingNotificationTap(notificationId));
+
+      if (tap) queueNotificationTap(tap);
+      else clearLastNotificationResponse();
+    } catch (error) {
+      console.warn("⚠️ Failed to handle notification tap", error);
     }
-
-    void getPendingNotificationTap(notificationId)
-      .then((storedTap) => {
-        if (storedTap) {
-          queueNotificationTap(storedTap);
-          return;
-        }
-
-        console.warn("⚠️ Notification tap data was not found", {
-          notificationId,
-        });
-        clearLastNotificationResponse();
-      })
-      .catch((error) => {
-        console.warn("⚠️ Failed to restore notification tap data", {
-          notificationId,
-          error,
-        });
-      });
   };
 
   /**
@@ -646,14 +630,14 @@ const App: React.FC = () => {
 
         console.log("👆 Notification tapped:", { data, tappedTime });
 
-        handleNotificationTap(notification.request.identifier, data);
+        void handleNotificationTap(notification.request.identifier, data);
       });
 
     void Notifications.getLastNotificationResponseAsync()
       .then((response) => {
         if (!response) return;
 
-        handleNotificationTap(
+        void handleNotificationTap(
           response.notification.request.identifier,
           response.notification.request.content.data
         );
@@ -772,7 +756,7 @@ const App: React.FC = () => {
             return;
           }
 
-          handleNotificationTap(
+          void handleNotificationTap(
             remoteMessage.messageId,
             remoteMessage.data
           );

--- a/App.tsx
+++ b/App.tsx
@@ -56,6 +56,12 @@ interface APP_PARAMS {
   fcmToken?: string;
 }
 
+interface PendingNotificationTap {
+  notificationId: string | null;
+  to: string;
+  from: string | null;
+}
+
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
     shouldPlaySound: true,
@@ -287,6 +293,9 @@ const App: React.FC = () => {
   const appState = useRef(AppState.currentState);
   const appResumeTimer = useRef<NodeJS.Timeout | null>(null);
   const webViewRef = useRef<WebView>(null);
+  const webBridgeReadyRef = useRef(false);
+  const pendingNotificationTapRef = useRef<PendingNotificationTap | null>(null);
+  const lastDeliveredNotificationIdRef = useRef<string | null>(null);
   const showNavBarRef = useRef(true); // Show navigation bar on app launch
   const [deviceToken, setDeviceToken] = useState<string | null>(null);
   const [expoPushToken, setExpoPushToken] = useState<string | null>(null);
@@ -401,14 +410,66 @@ const App: React.FC = () => {
     return () => sub.remove();
   }, []);
 
-  const sendMessageToWebView = (message: object) => {
+  const sendMessageToWebView = (message: object): boolean => {
     const messageJson = JSON.stringify(message);
-    if (webViewRef.current) {
-      const jsToInject = `window.dispatchEvent(new MessageEvent('message', { data: ${JSON.stringify(
-        messageJson
-      )} }));`;
-      webViewRef.current.injectJavaScript(jsToInject);
+    if (!webViewRef.current) return false;
+
+    const jsToInject = `window.dispatchEvent(new MessageEvent('message', { data: ${JSON.stringify(
+      messageJson
+    )} }));`;
+    webViewRef.current.injectJavaScript(jsToInject);
+    return true;
+  };
+
+  const flushPendingNotificationTap = () => {
+    const pendingTap = pendingNotificationTapRef.current;
+    if (!webBridgeReadyRef.current || !pendingTap) return;
+
+    const wasSent = sendMessageToWebView({
+      type: "NOTIFICATION_TAPPED",
+      to: pendingTap.to,
+      from: pendingTap.from,
+    });
+    if (!wasSent) return;
+
+    pendingNotificationTapRef.current = null;
+    lastDeliveredNotificationIdRef.current = pendingTap.notificationId;
+
+    void Notifications.clearLastNotificationResponseAsync().catch((error) => {
+      console.warn("⚠️ Failed to clear the last notification response:", error);
+    });
+  };
+
+  const queueNotificationTap = (
+    notificationId: string | null,
+    data: Record<string, unknown> | undefined
+  ) => {
+    if (!data) {
+      console.warn("⚠️ Notification tap is missing data");
+      return;
     }
+
+    const { to, from } = data;
+    if (typeof to !== "string" || to.length === 0) {
+      console.warn("⚠️ Notification tap is missing a recipient address");
+      return;
+    }
+
+    if (
+      notificationId &&
+      (notificationId === lastDeliveredNotificationIdRef.current ||
+        notificationId ===
+          pendingNotificationTapRef.current?.notificationId)
+    ) {
+      return;
+    }
+
+    pendingNotificationTapRef.current = {
+      notificationId,
+      to,
+      from: typeof from === "string" ? from : null,
+    };
+    flushPendingNotificationTap();
   };
 
   /**
@@ -560,28 +621,27 @@ const App: React.FC = () => {
     // Listen for notification response (when user taps notification)
     const notificationResponseListener =
       Notifications.addNotificationResponseReceivedListener((response) => {
-        const { notification, actionIdentifier } = response;
+        const { notification } = response;
         const { data } = notification.request.content;
         const tappedTime = new Date().toLocaleString();
 
         console.log("👆 Notification tapped:", { data, tappedTime });
 
-        // // Handle action button responses
-        // if (actionIdentifier === "CANCEL_CALL") {
-        //   console.log("❌ Cancel call button pressed");
-        //   // Clear the notification from the panel - no need to open app
-        //   Notifications.dismissNotificationAsync(
-        //     notification.request.identifier
-        //   );
-        // }
+        queueNotificationTap(notification.request.identifier, data);
+      });
 
-        setTimeout(() => {
-          sendMessageToWebView({
-            type: "NOTIFICATION_TAPPED",
-            to: data.to,
-            from: data.from,
-          });
-        }, 300);
+    void Notifications.getLastNotificationResponseAsync()
+      .then((response) => {
+        if (!response) return;
+
+        const { notification } = response;
+        queueNotificationTap(
+          notification.request.identifier,
+          notification.request.content.data
+        );
+      })
+      .catch((error) => {
+        console.warn("⚠️ Failed to get the last notification response:", error);
       });
 
     return () => {
@@ -689,6 +749,10 @@ const App: React.FC = () => {
             "📱 FCM message opened app from background:",
             remoteMessage
           );
+          queueNotificationTap(
+            remoteMessage.messageId ?? null,
+            remoteMessage.data
+          );
         }
       );
 
@@ -700,9 +764,15 @@ const App: React.FC = () => {
               "📱 FCM message opened app from killed state:",
               remoteMessage
             );
+            queueNotificationTap(
+              remoteMessage.messageId ?? null,
+              remoteMessage.data
+            );
           }
         }
-      );
+      ).catch((error) => {
+        console.warn("⚠️ Failed to get the initial FCM notification:", error);
+      });
 
       // Cleanup listeners
       return () => {
@@ -995,6 +1065,9 @@ const App: React.FC = () => {
   const handleWebViewMessage = async (event: any) => {
     try {
       const data = JSON.parse(event.nativeEvent.data);
+
+      webBridgeReadyRef.current = true;
+      flushPendingNotificationTap();
 
       // console.log("📡 Received message:", data);
 
@@ -1414,6 +1487,7 @@ const App: React.FC = () => {
               }}
               // Add load start handler
               onLoadStart={() => {
+                webBridgeReadyRef.current = false;
                 console.log("🔄 WebView load started");
               }}
               // WHITE SCREEN FIX ON IOS

--- a/App.tsx
+++ b/App.tsx
@@ -39,6 +39,12 @@ import {
 } from "@react-native-firebase/messaging";
 import type { FirebaseMessagingTypes } from "@react-native-firebase/messaging";
 import VoipPushNotification from "react-native-voip-push-notification";
+import {
+  clearPendingNotificationTap,
+  createNotificationTap,
+  getPendingNotificationTap,
+  type PendingNotificationTap,
+} from "./NotificationTap";
 
 const APP_URL = "https://liberdus.com/test/";
 
@@ -54,12 +60,6 @@ interface APP_PARAMS {
   expoPushToken?: string;
   voipToken?: string;
   fcmToken?: string;
-}
-
-interface PendingNotificationTap {
-  notificationId: string | null;
-  to: string;
-  from: string | null;
 }
 
 Notifications.setNotificationHandler({
@@ -434,37 +434,35 @@ const App: React.FC = () => {
 
     pendingNotificationTapRef.current = null;
     lastDeliveredNotificationIdRef.current = pendingTap.notificationId;
+    console.log("📱 Delivered notification tap data to the WebView");
+
+    void clearPendingNotificationTap(pendingTap.notificationId).catch(
+      (error) => {
+        console.warn("⚠️ Failed to clear the pending notification tap:", error);
+      }
+    );
 
     void Notifications.clearLastNotificationResponseAsync().catch((error) => {
       console.warn("⚠️ Failed to clear the last notification response:", error);
     });
   };
 
-  const queueNotificationTap = (
-    notificationId: string | null,
-    data: Record<string, unknown> | undefined
-  ) => {
-    const to = data?.to;
-    const from = data?.from;
-    if (typeof to !== "string" || to.length === 0) {
+  const queueNotificationTap = (tap: PendingNotificationTap | null) => {
+    if (!tap) {
       console.warn("⚠️ Notification tap is missing a recipient address");
       return;
     }
 
     if (
-      notificationId &&
-      (notificationId === lastDeliveredNotificationIdRef.current ||
-        notificationId ===
+      tap.notificationId &&
+      (tap.notificationId === lastDeliveredNotificationIdRef.current ||
+        tap.notificationId ===
           pendingNotificationTapRef.current?.notificationId)
     ) {
       return;
     }
 
-    pendingNotificationTapRef.current = {
-      notificationId,
-      to,
-      from: typeof from === "string" ? from : null,
-    };
+    pendingNotificationTapRef.current = tap;
     flushPendingNotificationTap();
   };
 
@@ -623,7 +621,9 @@ const App: React.FC = () => {
 
         console.log("👆 Notification tapped:", { data, tappedTime });
 
-        queueNotificationTap(notification.request.identifier, data);
+        queueNotificationTap(
+          createNotificationTap(notification.request.identifier, data)
+        );
       });
 
     void Notifications.getLastNotificationResponseAsync()
@@ -632,12 +632,25 @@ const App: React.FC = () => {
 
         const { notification } = response;
         queueNotificationTap(
-          notification.request.identifier,
-          notification.request.content.data
+          createNotificationTap(
+            notification.request.identifier,
+            notification.request.content.data
+          )
         );
       })
       .catch((error) => {
         console.warn("⚠️ Failed to get the last notification response:", error);
+      });
+
+    void getPendingNotificationTap()
+      .then((tap) => {
+        if (!tap) return;
+
+        console.log("📱 Restored pending notification tap data");
+        queueNotificationTap(tap);
+      })
+      .catch((error) => {
+        console.warn("⚠️ Failed to restore the pending notification tap:", error);
       });
 
     return () => {
@@ -746,8 +759,10 @@ const App: React.FC = () => {
             remoteMessage
           );
           queueNotificationTap(
-            remoteMessage.messageId ?? null,
-            remoteMessage.data
+            createNotificationTap(
+              remoteMessage.messageId ?? null,
+              remoteMessage.data
+            )
           );
         }
       );
@@ -762,8 +777,10 @@ const App: React.FC = () => {
                 remoteMessage
               );
               queueNotificationTap(
-                remoteMessage.messageId ?? null,
-                remoteMessage.data
+                createNotificationTap(
+                  remoteMessage.messageId ?? null,
+                  remoteMessage.data
+                )
               );
             }
           }

--- a/App.tsx
+++ b/App.tsx
@@ -34,7 +34,6 @@ import {
   getToken,
   onMessage,
   onNotificationOpenedApp,
-  getInitialNotification,
   AuthorizationStatus,
 } from "@react-native-firebase/messaging";
 import type { FirebaseMessagingTypes } from "@react-native-firebase/messaging";
@@ -421,6 +420,12 @@ const App: React.FC = () => {
     return true;
   };
 
+  const clearLastNotificationResponse = () => {
+    void Notifications.clearLastNotificationResponseAsync().catch((error) => {
+      console.warn("⚠️ Failed to clear the last notification response:", error);
+    });
+  };
+
   const flushPendingNotificationTap = () => {
     const pendingTap = pendingNotificationTapRef.current;
     if (!webBridgeReadyRef.current || !pendingTap) return;
@@ -441,28 +446,49 @@ const App: React.FC = () => {
       }
     );
 
-    void Notifications.clearLastNotificationResponseAsync().catch((error) => {
-      console.warn("⚠️ Failed to clear the last notification response:", error);
-    });
+    clearLastNotificationResponse();
   };
 
-  const queueNotificationTap = (tap: PendingNotificationTap | null) => {
-    if (!tap) {
-      console.warn("⚠️ Notification tap is missing a recipient address");
-      return;
-    }
-
+  const queueNotificationTap = (tap: PendingNotificationTap) => {
     if (
-      tap.notificationId &&
-      (tap.notificationId === lastDeliveredNotificationIdRef.current ||
-        tap.notificationId ===
-          pendingNotificationTapRef.current?.notificationId)
+      tap.notificationId === lastDeliveredNotificationIdRef.current ||
+      tap.notificationId === pendingNotificationTapRef.current?.notificationId
     ) {
       return;
     }
 
     pendingNotificationTapRef.current = tap;
     flushPendingNotificationTap();
+  };
+
+  const handleNotificationTap = (
+    notificationId: string,
+    data: Record<string, unknown> | undefined
+  ): void => {
+    const tap = createNotificationTap(notificationId, data);
+    if (tap) {
+      queueNotificationTap(tap);
+      return;
+    }
+
+    void getPendingNotificationTap(notificationId)
+      .then((storedTap) => {
+        if (storedTap) {
+          queueNotificationTap(storedTap);
+          return;
+        }
+
+        console.warn("⚠️ Notification tap data was not found", {
+          notificationId,
+        });
+        clearLastNotificationResponse();
+      })
+      .catch((error) => {
+        console.warn("⚠️ Failed to restore notification tap data", {
+          notificationId,
+          error,
+        });
+      });
   };
 
   /**
@@ -620,36 +646,20 @@ const App: React.FC = () => {
 
         console.log("👆 Notification tapped:", { data, tappedTime });
 
-        queueNotificationTap(
-          createNotificationTap(notification.request.identifier, data)
-        );
+        handleNotificationTap(notification.request.identifier, data);
       });
 
     void Notifications.getLastNotificationResponseAsync()
       .then((response) => {
         if (!response) return;
 
-        const { notification } = response;
-        queueNotificationTap(
-          createNotificationTap(
-            notification.request.identifier,
-            notification.request.content.data
-          )
+        handleNotificationTap(
+          response.notification.request.identifier,
+          response.notification.request.content.data
         );
       })
       .catch((error) => {
         console.warn("⚠️ Failed to get the last notification response:", error);
-      });
-
-    void getPendingNotificationTap()
-      .then((tap) => {
-        if (!tap) return;
-
-        console.log("📱 Restored pending notification tap data");
-        queueNotificationTap(tap);
-      })
-      .catch((error) => {
-        console.warn("⚠️ Failed to restore the pending notification tap:", error);
       });
 
     return () => {
@@ -757,36 +767,17 @@ const App: React.FC = () => {
             "📱 FCM message opened app from background:",
             remoteMessage
           );
-          queueNotificationTap(
-            createNotificationTap(
-              remoteMessage.messageId ?? null,
-              remoteMessage.data
-            )
+          if (!remoteMessage.messageId) {
+            console.warn("⚠️ Opened FCM notification has no message ID");
+            return;
+          }
+
+          handleNotificationTap(
+            remoteMessage.messageId,
+            remoteMessage.data
           );
         }
       );
-
-      // Handle messages when app is completely killed and opened by notification
-      void getInitialNotification(messagingInstance)
-        .then(
-          (remoteMessage: FirebaseMessagingTypes.RemoteMessage | null) => {
-            if (remoteMessage) {
-              console.log(
-                "📱 FCM message opened app from killed state:",
-                remoteMessage
-              );
-              queueNotificationTap(
-                createNotificationTap(
-                  remoteMessage.messageId ?? null,
-                  remoteMessage.data
-                )
-              );
-            }
-          }
-        )
-        .catch((error) => {
-          console.warn("⚠️ Failed to get the initial FCM notification:", error);
-        });
 
       // Cleanup listeners
       return () => {

--- a/App.tsx
+++ b/App.tsx
@@ -444,12 +444,8 @@ const App: React.FC = () => {
     notificationId: string | null,
     data: Record<string, unknown> | undefined
   ) => {
-    if (!data) {
-      console.warn("⚠️ Notification tap is missing data");
-      return;
-    }
-
-    const { to, from } = data;
+    const to = data?.to;
+    const from = data?.from;
     if (typeof to !== "string" || to.length === 0) {
       console.warn("⚠️ Notification tap is missing a recipient address");
       return;
@@ -757,22 +753,24 @@ const App: React.FC = () => {
       );
 
       // Handle messages when app is completely killed and opened by notification
-      getInitialNotification(messagingInstance).then(
-        (remoteMessage: FirebaseMessagingTypes.RemoteMessage | null) => {
-          if (remoteMessage) {
-            console.log(
-              "📱 FCM message opened app from killed state:",
-              remoteMessage
-            );
-            queueNotificationTap(
-              remoteMessage.messageId ?? null,
-              remoteMessage.data
-            );
+      void getInitialNotification(messagingInstance)
+        .then(
+          (remoteMessage: FirebaseMessagingTypes.RemoteMessage | null) => {
+            if (remoteMessage) {
+              console.log(
+                "📱 FCM message opened app from killed state:",
+                remoteMessage
+              );
+              queueNotificationTap(
+                remoteMessage.messageId ?? null,
+                remoteMessage.data
+              );
+            }
           }
-        }
-      ).catch((error) => {
-        console.warn("⚠️ Failed to get the initial FCM notification:", error);
-      });
+        )
+        .catch((error) => {
+          console.warn("⚠️ Failed to get the initial FCM notification:", error);
+        });
 
       // Cleanup listeners
       return () => {
@@ -1066,6 +1064,7 @@ const App: React.FC = () => {
     try {
       const data = JSON.parse(event.nativeEvent.data);
 
+      // The WebView installs its native-message listener before posting here.
       webBridgeReadyRef.current = true;
       flushPendingNotificationTap();
 

--- a/App.tsx
+++ b/App.tsx
@@ -428,7 +428,6 @@ const App: React.FC = () => {
     const wasSent = sendMessageToWebView({
       type: "NOTIFICATION_TAPPED",
       to: pendingTap.to,
-      from: pendingTap.from,
     });
     if (!wasSent) return;
 

--- a/NotificationTap.ts
+++ b/NotificationTap.ts
@@ -4,40 +4,39 @@ const PENDING_NOTIFICATION_TAP_KEY = "pending_notification_tap";
 
 type NotificationData = Record<string, unknown>;
 
+const isRecord = (value: unknown): value is NotificationData =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 export interface PendingNotificationTap {
   notificationId: string | null;
   to: string;
-  from: string | null;
 }
-
-const parseObject = (value: unknown): NotificationData | null => {
-  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-    return value as NotificationData;
-  }
-
-  if (typeof value !== "string") return null;
-
-  try {
-    return parseObject(JSON.parse(value));
-  } catch {
-    return null;
-  }
-};
 
 export const createNotificationTap = (
   notificationId: string | null,
   data: NotificationData | undefined
 ): PendingNotificationTap | null => {
-  const bodyData = parseObject(data?.body);
-  const to = data?.to ?? bodyData?.to;
-  const from = data?.from ?? bodyData?.from;
+  if (typeof data?.body !== "string") return null;
 
-  if (typeof to !== "string" || to.length === 0) return null;
+  let body: unknown;
+  try {
+    body = JSON.parse(data.body);
+  } catch {
+    return null;
+  }
+
+  if (
+    !isRecord(body) ||
+    body.type !== "message" ||
+    typeof body.to !== "string" ||
+    body.to.length === 0
+  ) {
+    return null;
+  }
 
   return {
     notificationId,
-    to,
-    from: typeof from === "string" ? from : null,
+    to: body.to,
   };
 };
 
@@ -50,24 +49,29 @@ export const storePendingNotificationTap = async (
 export const getPendingNotificationTap = async (): Promise<
   PendingNotificationTap | null
 > => {
-  const storedTap = parseObject(
-    await AsyncStorage.getItem(PENDING_NOTIFICATION_TAP_KEY)
-  );
-  if (!storedTap) return null;
+  const storedValue = await AsyncStorage.getItem(PENDING_NOTIFICATION_TAP_KEY);
+  if (!storedValue) return null;
+
+  let storedTap: unknown;
+  try {
+    storedTap = JSON.parse(storedValue);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(storedTap)) return null;
 
   const notificationId = storedTap.notificationId;
   const to = storedTap.to;
-  const from = storedTap.from;
 
   if (
     (typeof notificationId !== "string" && notificationId !== null) ||
-    typeof to !== "string" ||
-    (typeof from !== "string" && from !== null)
+    typeof to !== "string"
   ) {
     return null;
   }
 
-  return { notificationId, to, from };
+  return { notificationId, to };
 };
 
 export const clearPendingNotificationTap = async (

--- a/NotificationTap.ts
+++ b/NotificationTap.ts
@@ -4,6 +4,7 @@ const PENDING_NOTIFICATION_TAP_KEY = "pending_notification_tap";
 const MAX_PENDING_NOTIFICATION_TAPS = 20;
 
 type NotificationData = Record<string, unknown>;
+type StoredNotificationTaps = Record<string, string>;
 
 const isRecord = (value: unknown): value is NotificationData =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -41,88 +42,62 @@ export const createNotificationTap = (
   };
 };
 
-const parsePendingNotificationTap = (
-  value: unknown
-): PendingNotificationTap | null => {
-  if (!isRecord(value)) return null;
-
-  const notificationId = value.notificationId;
-  const to = value.to;
-
-  if (
-    typeof notificationId !== "string" ||
-    notificationId.length === 0 ||
-    typeof to !== "string" ||
-    to.length === 0
-  ) {
-    return null;
-  }
-
-  return { notificationId, to };
-};
-
-const getPendingNotificationTaps = async (): Promise<
-  PendingNotificationTap[]
-> => {
+const getStoredNotificationTaps = async (): Promise<StoredNotificationTaps> => {
   const storedValue = await AsyncStorage.getItem(PENDING_NOTIFICATION_TAP_KEY);
-  if (!storedValue) return [];
+  if (!storedValue) return {};
 
-  let storedTaps: unknown;
   try {
-    storedTaps = JSON.parse(storedValue);
+    const storedTaps: unknown = JSON.parse(storedValue);
+    if (!isRecord(storedTaps)) return {};
+
+    return Object.fromEntries(
+      Object.entries(storedTaps).filter(
+        ([notificationId, to]) =>
+          notificationId.length > 0 && typeof to === "string" && to.length > 0
+      )
+    ) as StoredNotificationTaps;
   } catch {
-    return [];
+    return {};
   }
-
-  if (!Array.isArray(storedTaps)) return [];
-
-  return storedTaps
-    .map(parsePendingNotificationTap)
-    .filter((tap): tap is PendingNotificationTap => tap !== null);
 };
 
 export const storePendingNotificationTap = async (
   tap: PendingNotificationTap
 ): Promise<void> => {
-  const storedTaps = await getPendingNotificationTaps();
-  const pendingTaps = [
-    tap,
-    ...storedTaps.filter(
-      (storedTap) => storedTap.notificationId !== tap.notificationId
-    ),
-  ].slice(0, MAX_PENDING_NOTIFICATION_TAPS);
+  const storedTaps = await getStoredNotificationTaps();
+  delete storedTaps[tap.notificationId];
+  storedTaps[tap.notificationId] = tap.to;
 
   await AsyncStorage.setItem(
     PENDING_NOTIFICATION_TAP_KEY,
-    JSON.stringify(pendingTaps)
+    JSON.stringify(
+      Object.fromEntries(
+        Object.entries(storedTaps).slice(-MAX_PENDING_NOTIFICATION_TAPS)
+      )
+    )
   );
 };
 
 export const getPendingNotificationTap = async (
   notificationId: string
 ): Promise<PendingNotificationTap | null> => {
-  const storedTaps = await getPendingNotificationTaps();
-  return (
-    storedTaps.find((tap) => tap.notificationId === notificationId) ?? null
-  );
+  const to = (await getStoredNotificationTaps())[notificationId];
+  return to ? { notificationId, to } : null;
 };
 
 export const clearPendingNotificationTap = async (
   notificationId: string
 ): Promise<void> => {
-  const storedTaps = await getPendingNotificationTaps();
-  const remainingTaps = storedTaps.filter(
-    (tap) => tap.notificationId !== notificationId
-  );
-  if (remainingTaps.length === storedTaps.length) return;
+  const storedTaps = await getStoredNotificationTaps();
+  if (!(notificationId in storedTaps)) return;
 
-  if (remainingTaps.length > 0) {
+  delete storedTaps[notificationId];
+  if (Object.keys(storedTaps).length > 0) {
     await AsyncStorage.setItem(
       PENDING_NOTIFICATION_TAP_KEY,
-      JSON.stringify(remainingTaps)
+      JSON.stringify(storedTaps)
     );
-    return;
+  } else {
+    await AsyncStorage.removeItem(PENDING_NOTIFICATION_TAP_KEY);
   }
-
-  await AsyncStorage.removeItem(PENDING_NOTIFICATION_TAP_KEY);
 };

--- a/NotificationTap.ts
+++ b/NotificationTap.ts
@@ -1,0 +1,80 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const PENDING_NOTIFICATION_TAP_KEY = "pending_notification_tap";
+
+type NotificationData = Record<string, unknown>;
+
+export interface PendingNotificationTap {
+  notificationId: string | null;
+  to: string;
+  from: string | null;
+}
+
+const parseObject = (value: unknown): NotificationData | null => {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as NotificationData;
+  }
+
+  if (typeof value !== "string") return null;
+
+  try {
+    return parseObject(JSON.parse(value));
+  } catch {
+    return null;
+  }
+};
+
+export const createNotificationTap = (
+  notificationId: string | null,
+  data: NotificationData | undefined
+): PendingNotificationTap | null => {
+  const bodyData = parseObject(data?.body);
+  const to = data?.to ?? bodyData?.to;
+  const from = data?.from ?? bodyData?.from;
+
+  if (typeof to !== "string" || to.length === 0) return null;
+
+  return {
+    notificationId,
+    to,
+    from: typeof from === "string" ? from : null,
+  };
+};
+
+export const storePendingNotificationTap = async (
+  tap: PendingNotificationTap
+): Promise<void> => {
+  await AsyncStorage.setItem(PENDING_NOTIFICATION_TAP_KEY, JSON.stringify(tap));
+};
+
+export const getPendingNotificationTap = async (): Promise<
+  PendingNotificationTap | null
+> => {
+  const storedTap = parseObject(
+    await AsyncStorage.getItem(PENDING_NOTIFICATION_TAP_KEY)
+  );
+  if (!storedTap) return null;
+
+  const notificationId = storedTap.notificationId;
+  const to = storedTap.to;
+  const from = storedTap.from;
+
+  if (
+    (typeof notificationId !== "string" && notificationId !== null) ||
+    typeof to !== "string" ||
+    (typeof from !== "string" && from !== null)
+  ) {
+    return null;
+  }
+
+  return { notificationId, to, from };
+};
+
+export const clearPendingNotificationTap = async (
+  notificationId: string | null
+): Promise<void> => {
+  const storedTap = await getPendingNotificationTap();
+  if (!storedTap || storedTap.notificationId !== notificationId) return;
+
+  await AsyncStorage.removeItem(PENDING_NOTIFICATION_TAP_KEY);
+};

--- a/NotificationTap.ts
+++ b/NotificationTap.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const PENDING_NOTIFICATION_TAP_KEY = "pending_notification_tap";
+const MAX_PENDING_NOTIFICATION_TAPS = 20;
 
 type NotificationData = Record<string, unknown>;
 
@@ -8,12 +9,12 @@ const isRecord = (value: unknown): value is NotificationData =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
 export interface PendingNotificationTap {
-  notificationId: string | null;
+  notificationId: string;
   to: string;
 }
 
 export const createNotificationTap = (
-  notificationId: string | null,
+  notificationId: string,
   data: NotificationData | undefined
 ): PendingNotificationTap | null => {
   if (typeof data?.body !== "string") return null;
@@ -40,33 +41,19 @@ export const createNotificationTap = (
   };
 };
 
-export const storePendingNotificationTap = async (
-  tap: PendingNotificationTap
-): Promise<void> => {
-  await AsyncStorage.setItem(PENDING_NOTIFICATION_TAP_KEY, JSON.stringify(tap));
-};
+const parsePendingNotificationTap = (
+  value: unknown
+): PendingNotificationTap | null => {
+  if (!isRecord(value)) return null;
 
-export const getPendingNotificationTap = async (): Promise<
-  PendingNotificationTap | null
-> => {
-  const storedValue = await AsyncStorage.getItem(PENDING_NOTIFICATION_TAP_KEY);
-  if (!storedValue) return null;
-
-  let storedTap: unknown;
-  try {
-    storedTap = JSON.parse(storedValue);
-  } catch {
-    return null;
-  }
-
-  if (!isRecord(storedTap)) return null;
-
-  const notificationId = storedTap.notificationId;
-  const to = storedTap.to;
+  const notificationId = value.notificationId;
+  const to = value.to;
 
   if (
-    (typeof notificationId !== "string" && notificationId !== null) ||
-    typeof to !== "string"
+    typeof notificationId !== "string" ||
+    notificationId.length === 0 ||
+    typeof to !== "string" ||
+    to.length === 0
   ) {
     return null;
   }
@@ -74,11 +61,68 @@ export const getPendingNotificationTap = async (): Promise<
   return { notificationId, to };
 };
 
-export const clearPendingNotificationTap = async (
-  notificationId: string | null
+const getPendingNotificationTaps = async (): Promise<
+  PendingNotificationTap[]
+> => {
+  const storedValue = await AsyncStorage.getItem(PENDING_NOTIFICATION_TAP_KEY);
+  if (!storedValue) return [];
+
+  let storedTaps: unknown;
+  try {
+    storedTaps = JSON.parse(storedValue);
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(storedTaps)) return [];
+
+  return storedTaps
+    .map(parsePendingNotificationTap)
+    .filter((tap): tap is PendingNotificationTap => tap !== null);
+};
+
+export const storePendingNotificationTap = async (
+  tap: PendingNotificationTap
 ): Promise<void> => {
-  const storedTap = await getPendingNotificationTap();
-  if (!storedTap || storedTap.notificationId !== notificationId) return;
+  const storedTaps = await getPendingNotificationTaps();
+  const pendingTaps = [
+    tap,
+    ...storedTaps.filter(
+      (storedTap) => storedTap.notificationId !== tap.notificationId
+    ),
+  ].slice(0, MAX_PENDING_NOTIFICATION_TAPS);
+
+  await AsyncStorage.setItem(
+    PENDING_NOTIFICATION_TAP_KEY,
+    JSON.stringify(pendingTaps)
+  );
+};
+
+export const getPendingNotificationTap = async (
+  notificationId: string
+): Promise<PendingNotificationTap | null> => {
+  const storedTaps = await getPendingNotificationTaps();
+  return (
+    storedTaps.find((tap) => tap.notificationId === notificationId) ?? null
+  );
+};
+
+export const clearPendingNotificationTap = async (
+  notificationId: string
+): Promise<void> => {
+  const storedTaps = await getPendingNotificationTaps();
+  const remainingTaps = storedTaps.filter(
+    (tap) => tap.notificationId !== notificationId
+  );
+  if (remainingTaps.length === storedTaps.length) return;
+
+  if (remainingTaps.length > 0) {
+    await AsyncStorage.setItem(
+      PENDING_NOTIFICATION_TAP_KEY,
+      JSON.stringify(remainingTaps)
+    );
+    return;
+  }
 
   await AsyncStorage.removeItem(PENDING_NOTIFICATION_TAP_KEY);
 };

--- a/NotificationTap.ts
+++ b/NotificationTap.ts
@@ -6,6 +6,8 @@ const MAX_PENDING_NOTIFICATION_TAPS = 20;
 type NotificationData = Record<string, unknown>;
 type StoredNotificationTaps = Record<string, string>;
 
+let pendingTapStorageQueue: Promise<void> = Promise.resolve();
+
 const isRecord = (value: unknown): value is NotificationData =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
@@ -18,6 +20,10 @@ export const createNotificationTap = (
   notificationId: string,
   data: NotificationData | undefined
 ): PendingNotificationTap | null => {
+  if (typeof data?.to === "string" && data.to.length > 0) {
+    return { notificationId, to: data.to };
+  }
+
   if (typeof data?.body !== "string") return null;
 
   let body: unknown;
@@ -42,6 +48,17 @@ export const createNotificationTap = (
   };
 };
 
+const withPendingTapStorage = <T>(
+  operation: () => Promise<T>
+): Promise<T> => {
+  const result = pendingTapStorageQueue.then(operation);
+  pendingTapStorageQueue = result.then(
+    () => undefined,
+    () => undefined
+  );
+  return result;
+};
+
 const getStoredNotificationTaps = async (): Promise<StoredNotificationTaps> => {
   const storedValue = await AsyncStorage.getItem(PENDING_NOTIFICATION_TAP_KEY);
   if (!storedValue) return {};
@@ -61,43 +78,46 @@ const getStoredNotificationTaps = async (): Promise<StoredNotificationTaps> => {
   }
 };
 
-export const storePendingNotificationTap = async (
+export const storePendingNotificationTap = (
   tap: PendingNotificationTap
-): Promise<void> => {
-  const storedTaps = await getStoredNotificationTaps();
-  delete storedTaps[tap.notificationId];
-  storedTaps[tap.notificationId] = tap.to;
+): Promise<void> =>
+  withPendingTapStorage(async () => {
+    const storedTaps = await getStoredNotificationTaps();
+    delete storedTaps[tap.notificationId];
+    storedTaps[tap.notificationId] = tap.to;
 
-  await AsyncStorage.setItem(
-    PENDING_NOTIFICATION_TAP_KEY,
-    JSON.stringify(
-      Object.fromEntries(
-        Object.entries(storedTaps).slice(-MAX_PENDING_NOTIFICATION_TAPS)
-      )
-    )
-  );
-};
-
-export const getPendingNotificationTap = async (
-  notificationId: string
-): Promise<PendingNotificationTap | null> => {
-  const to = (await getStoredNotificationTaps())[notificationId];
-  return to ? { notificationId, to } : null;
-};
-
-export const clearPendingNotificationTap = async (
-  notificationId: string
-): Promise<void> => {
-  const storedTaps = await getStoredNotificationTaps();
-  if (!(notificationId in storedTaps)) return;
-
-  delete storedTaps[notificationId];
-  if (Object.keys(storedTaps).length > 0) {
     await AsyncStorage.setItem(
       PENDING_NOTIFICATION_TAP_KEY,
-      JSON.stringify(storedTaps)
+      JSON.stringify(
+        Object.fromEntries(
+          Object.entries(storedTaps).slice(-MAX_PENDING_NOTIFICATION_TAPS)
+        )
+      )
     );
-  } else {
-    await AsyncStorage.removeItem(PENDING_NOTIFICATION_TAP_KEY);
-  }
-};
+  });
+
+export const getPendingNotificationTap = (
+  notificationId: string
+): Promise<PendingNotificationTap | null> =>
+  withPendingTapStorage(async () => {
+    const to = (await getStoredNotificationTaps())[notificationId];
+    return to ? { notificationId, to } : null;
+  });
+
+export const clearPendingNotificationTap = (
+  notificationId: string
+): Promise<void> =>
+  withPendingTapStorage(async () => {
+    const storedTaps = await getStoredNotificationTaps();
+    if (!(notificationId in storedTaps)) return;
+
+    delete storedTaps[notificationId];
+    if (Object.keys(storedTaps).length > 0) {
+      await AsyncStorage.setItem(
+        PENDING_NOTIFICATION_TAP_KEY,
+        JSON.stringify(storedTaps)
+      );
+    } else {
+      await AsyncStorage.removeItem(PENDING_NOTIFICATION_TAP_KEY);
+    }
+  });

--- a/index.ts
+++ b/index.ts
@@ -76,24 +76,13 @@ if (Platform.OS == "android") {
         const isCallMessage = remoteMessage.data?.type === "incoming_call";
 
         if (!isCallMessage) {
-          if (!remoteMessage.messageId) {
-            console.warn("⚠️ Background notification has no message ID");
-            return;
-          }
+          const notificationTap = remoteMessage.messageId
+            ? createNotificationTap(remoteMessage.messageId, remoteMessage.data)
+            : null;
 
-          const notificationTap = createNotificationTap(
-            remoteMessage.messageId,
-            remoteMessage.data
-          );
-          if (!notificationTap) {
-            console.warn(
-              "⚠️ Background notification is missing a recipient address"
-            );
-            return;
+          if (notificationTap) {
+            await storePendingNotificationTap(notificationTap);
           }
-
-          await storePendingNotificationTap(notificationTap);
-          console.log("📱 Background: Stored notification tap data");
           return;
         }
 

--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,10 @@ import {
   isStaleCallNotification,
 } from "./CallKeepOptions";
 import RNCallKeep from "react-native-callkeep";
+import {
+  createNotificationTap,
+  storePendingNotificationTap,
+} from "./NotificationTap";
 
 const MESSAGE_IDS_KEY = "processed_message_ids";
 const MAX_STORED_MESSAGES = 5;
@@ -72,7 +76,19 @@ if (Platform.OS == "android") {
         const isCallMessage = remoteMessage.data?.type === "incoming_call";
 
         if (!isCallMessage) {
-          console.log("📱 Background: Non-call message, ignoring");
+          const notificationTap = createNotificationTap(
+            remoteMessage.messageId ?? null,
+            remoteMessage.data
+          );
+          if (!notificationTap) {
+            console.warn(
+              "⚠️ Background notification is missing a recipient address"
+            );
+            return;
+          }
+
+          await storePendingNotificationTap(notificationTap);
+          console.log("📱 Background: Stored notification tap data");
           return;
         }
 

--- a/index.ts
+++ b/index.ts
@@ -76,8 +76,13 @@ if (Platform.OS == "android") {
         const isCallMessage = remoteMessage.data?.type === "incoming_call";
 
         if (!isCallMessage) {
+          if (!remoteMessage.messageId) {
+            console.warn("⚠️ Background notification has no message ID");
+            return;
+          }
+
           const notificationTap = createNotificationTap(
-            remoteMessage.messageId ?? null,
+            remoteMessage.messageId,
             remoteMessage.data
           );
           if (!notificationTap) {


### PR DESCRIPTION
## What Changed

This PR preserves notification-tap recipient data across an Android cold start and delivers it after the WebView bridge is ready.

- Normalizes both direct `data.to` payloads and current nested message payloads.
- Persists background message recipients by Firebase message ID and restores only the tapped notification.
- Queues the tap in memory until the WebView sends its first bridge message, then delivers `NOTIFICATION_TAPPED` once.
- Serializes pending-tap storage operations so concurrent background messages cannot overwrite one another.
- Keeps scheduled-call notification taps working with their direct recipient payload.

## Fixed Flow

1. Android receives a message while the app is backgrounded or fully closed.
2. Native code persists the message ID and recipient address.
3. Tapping the notification launches or resumes the app and identifies the matching pending record.
4. The native app waits until the WebView listener is installed, sends `NOTIFICATION_TAPPED`, and clears the consumed response and stored record.
5. Duplicate Expo and Firebase open events for the same notification are ignored.

## Why

The previous fixed delay could fire before the WebView existed, permanently losing the tap. On cold starts, Expo may also expose an incomplete response, so matching the persisted Firebase payload by notification ID provides a durable source of truth until the bridge is ready.

## iOS Impact

The Firebase background handler and AsyncStorage persistence added by this PR are Android-only. iOS push registration, Expo notification receipt, and VoIP notification handling are unchanged. iOS notification taps still use the shared Expo response listener; the only behavioral change in that path is replacing the fixed 300 ms delay with the WebView-readiness handoff. Direct `data.to` payloads remain supported, so the existing iOS tap contract should not regress.

## Validation

- `./node_modules/.bin/tsc --noEmit --moduleResolution bundler`
- `git diff --check 7749fecf361a6d0426066a87e83ec1bec7b6ad1e`

Closes #33